### PR TITLE
Add support for parsing YAML key-value files

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,7 @@
 const vscode = require('vscode');
 const path = require('path');
 const fs = require('fs');
+const YAML = require('yaml')
 const common = require('./out/extension-common');
 const utils = require('./utils');
 
@@ -349,7 +350,9 @@ function activate(context) {
     let jsonExpr = args.json;
     if (jsonExpr) {
       jsonExpr = await variableSubstitution(jsonExpr, args);
-      let value = getExpressionFunction(jsonExpr)(JSON.parse(content));
+      let isYaml = args.fileName.endsWith(".yaml") || args.fileName.endsWith(".yml");
+      let parsedContent = isYaml ? YAML.parse(content) : JSON.parse(content);
+      let value = getExpressionFunction(jsonExpr)(parsedContent);
       if (value === undefined) { return value; }
       return String(value);
     }

--- a/package.json
+++ b/package.json
@@ -5,11 +5,31 @@
   "publisher": "rioj7",
   "license": "MIT",
   "version": "1.42.2",
-  "engines": {"vscode": "^1.55.0"},
-  "categories": ["Other"],
-  "keywords": ["command","variable","launch","tasks","date","multi-root ready","pick","file","key","value","uuid","clipboard"],
+  "engines": {
+    "vscode": "^1.55.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "keywords": [
+    "command",
+    "variable",
+    "launch",
+    "tasks",
+    "date",
+    "multi-root ready",
+    "pick",
+    "file",
+    "key",
+    "value",
+    "uuid",
+    "clipboard"
+  ],
   "icon": "images/icon.png",
-  "galleryBanner": {"color": "#000080", "theme": "dark"},
+  "galleryBanner": {
+    "color": "#000080",
+    "theme": "dark"
+  },
   "activationEvents": [
     "onCommand:extension.commandvariable.file.relativeDirDots",
     "onCommand:extension.commandvariable.file.relativeFileDots",
@@ -124,5 +144,8 @@
     "mocha": "^9.1.3",
     "rollup": "^2.48.0",
     "simple-mock": "^0.8.0"
+  },
+  "dependencies": {
+    "yaml": "^2.1.3"
   }
 }


### PR DESCRIPTION
I'd like to propose an update to support reading from YAML files as well JSON files when parsing key-value file content. It's a fairly small scope change to add support (switching the parser based on simple file extension check), so I was hoping you'd consider approving this modification. Please let me know your thoughts and if you have any suggestions on the approach. Thank you!