### PR TITLE
Add variableSubstArgs property to named arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1756,6 +1756,7 @@ The named arguments have the following properties:
 
 * `command` : the commandID to execute
 * `args` : the arguments for this commandID
+* `variableSubstArgs` : if `true`, [variables](#variables) will be expanded within the `args` prior to the command being executed
 
 ```json
 {
@@ -1784,6 +1785,55 @@ The named arguments have the following properties:
           }
         }
       }
+    }
+  ]
+}
+```
+
+The following example shows how the `variableSubstArgs` option can be used to expand variables in a command used as a named argument. In this case, the [<code>&dollar;{pickStringRemember:pickAnOption}</code>](#variable-pickstringremember) variable is expanded prior to the argument being passed to the `shellCommand.execute` command (provided by the [Tasks Shell Input](https://marketplace.visualstudio.com/items?itemName=augustocdias.tasks-shell-input) extension).
+
+```json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Get Option String",
+      "type": "shell",
+      "command": "echo \"The option string is '${input:getOptionString}' and the selection option is '${input:selectedOption}'\""
+    }
+  ],
+  "inputs": [
+    {
+      "id": "getOptionString",
+      "type": "command",
+      "command": "extension.commandvariable.transform",
+      "args": {
+        "key": "optionString",
+        "text": "${command:getOptionString}",
+        "command": {
+          "getOptionString": {
+            "command": "shellCommand.execute",
+            "variableSubstArgs": true,
+            "args": {
+              "command": "echo You selected ${pickStringRemember:pickAnOption}",
+              "useSingleResult": true,
+              "pickStringRemember": {
+                "pickAnOption": {
+                  "key": "selectedOption",
+                  "description": "Pick an option",
+                  "options": [ "Option A", "Option B" ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "selectedOption",
+      "type": "command",
+      "command": "extension.commandvariable.transform",
+      "args": { "text": "${remember:selectedOption}" }
     }
   ]
 }


### PR DESCRIPTION
This PR adds the `variableSubstArgs` property as suggested in https://github.com/rioj7/command-variable/issues/50 in order to allow for expansion of variables in named arguments.