### PR TITLE
bugfix: jsonRepl doesn't correctly default when not present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1319,7 +1319,7 @@ The command has the following configuration attributes:
   * `flags` : (Optional) The flags to be used in the regular expression, like `gimsy`, default (`""`)
   * `label`: (Optional) A string containing capture group references <code>&dollar;<em>n</em></code> (like `$1`) that makes up the _label_ in the pickList. (default: `$1` )
   * `value`: (Optional) A string containing capture group references <code>&dollar;<em>n</em></code> (like `$1`) that makes up the _value_ in the pickList. (default: the same as `label`)
-  * `json`: (Optional) A string containing a capture group reference <code>&dollar;<em>n</em></code> (like `$1`) that makes up the _value_ object in the pickList. You have to write the `regexp` to recognize a possible JSON object string.
+  * `json`: (Optional) A string containing a capture group reference <code>&dollar;<em>n</em></code> (like `$1`) that makes up the _value_ object in the pickList. You have to write the `regexp` to recognize a possible JSON object string. (default: `""`)
   * `match`: (Optional) How should the `regexp` be applied. (default: `"line"` )  
     Possible values:  
     * `line` : the file content is parsed line by line and the `regexp` is used to create an option if a match is found.

--- a/extension.js
+++ b/extension.js
@@ -951,7 +951,7 @@ function activate(context) {
           let regexp = new RegExp(getProperty(pattern, 'regexp', '^(.*)$'), getProperty(pattern, 'flags', ''));
           let labelRepl = getProperty(pattern, 'label', '$1');
           let valueRepl = getProperty(pattern, 'value', labelRepl);
-          let jsonRepl = getProperty(pattern, 'json');
+          let jsonRepl = getProperty(pattern, 'json', '');
           let option = getProperty(pattern, 'option', {label: labelRepl, value: valueRepl, json: jsonRepl});
           let patternMatch = getProperty(pattern, 'match', 'line');
           let splitRegexp = getProperty(pattern, 'split-regexp');


### PR DESCRIPTION
Seems like this was a regression introduced in 2146b74e83267657ed56889ff8d0adf12f55f4a7

To replicate this bug:

Given `services.txt`
```
lmnop
galactus
bingo
rgs
```

in my launch.json
```json
        {
            "id": "pickService",
            "type": "command",
            "command": "extension.commandvariable.pickStringRemember",
            "args": {
                "key": "service",
                "description": "Select a service to debug",
                "fileName": "${workspaceFolder}/.vscode/debug_options/services.txt",
                "pattern": {
                    "regexp": "^(.+)$", // default
                    "label": "$1" // default
                }
            }
        },
```
the prompt won't show anything. I think this is because the default value of `getProperty(pattern, 'json')` here is `undefined`, and that gets passed around through `dataStructSubstitution` and `convertString` until it eventually gets to running this in convertString:
```
"lmnop".replace(new RegExp("^(.+)$", undefined) // which returns string "undefined"
```
classic javascript. And on line `963 -965`
```
 if (option.json !== undefined && isString(option.json) && option.json.length > 0) {
              option.value = JSON.parse(option.json);
}
```
the condition is `true`, and so we try to `JSON.parse("undefined")` and get a parse error. I think maybe you'll want to catch JSON SyntaxErrors in some way or handle it gracefully? I'll leave that up to you.

Trying the same config with
```
                "pattern": {
                    "regexp": "^(.+)$", // default
                    "label": "$1" // default
                    "json": ""
                }
```
works as expected.